### PR TITLE
Add support for animated WebP

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,5 +64,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation "com.github.bumptech.glide:glide:${glideVersion}"
     implementation "com.github.bumptech.glide:okhttp3-integration:${glideVersion}"
+    implementation "com.github.zjupure:webpdecoder:2.0.${glideVersion}"
     annotationProcessor "com.github.bumptech.glide:compiler:${glideVersion}"
 }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageRequestListener.java
@@ -2,6 +2,7 @@ package com.dylanvann.fastimage;
 
 import android.graphics.drawable.Drawable;
 
+import com.bumptech.glide.integration.webp.decoder.WebpDrawable;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
@@ -24,9 +25,11 @@ public class FastImageRequestListener implements RequestListener<Drawable> {
     }
 
     private static WritableMap mapFromResource(Drawable resource) {
+        boolean isAnimated = (resource instanceof WebpDrawable) && ((WebpDrawable) resource).getFrameCount() > 1;
         WritableMap resourceData = new WritableNativeMap();
         resourceData.putInt("width", resource.getIntrinsicWidth());
         resourceData.putInt("height", resource.getIntrinsicHeight());
+        resourceData.putBoolean("isAnimated", isAnimated);
         return resourceData;
     }
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewConverter.java
@@ -4,15 +4,11 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
-import android.media.Image;
-import android.net.Uri;
-import android.util.Log;
 import android.widget.ImageView;
 import android.widget.ImageView.ScaleType;
 
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.Headers;
 import com.bumptech.glide.load.model.LazyHeaders;
 import com.bumptech.glide.request.RequestOptions;
@@ -21,15 +17,9 @@ import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.NoSuchKeyException;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
-import com.facebook.react.views.imagehelper.ImageSource;
-
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
 
 import static com.bumptech.glide.request.RequestOptions.signatureOf;
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -4,12 +4,16 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
+import com.bumptech.glide.integration.webp.decoder.WebpDrawable;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.request.Request;
+import com.bumptech.glide.request.target.DrawableImageViewTarget;
+import com.bumptech.glide.request.transition.Transition;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
@@ -30,6 +34,8 @@ import javax.annotation.Nullable;
 import static com.dylanvann.fastimage.FastImageRequestListener.REACT_ON_ERROR_EVENT;
 import static com.dylanvann.fastimage.FastImageRequestListener.REACT_ON_LOAD_END_EVENT;
 import static com.dylanvann.fastimage.FastImageRequestListener.REACT_ON_LOAD_EVENT;
+
+import androidx.annotation.NonNull;
 
 class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> implements FastImageProgressListener {
 
@@ -124,7 +130,17 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
                     .load(imageSource.getSourceForLoad())
                     .apply(FastImageViewConverter.getOptions(context, imageSource, source))
                     .listener(new FastImageRequestListener(key))
-                    .into(view);
+                    .into(new DrawableImageViewTarget(view) {
+                        @Override
+                        public void onResourceReady(@NonNull Drawable resource, @Nullable Transition<? super Drawable> transition) {
+                            super.onResourceReady(resource, transition);
+                            if (resource instanceof WebpDrawable) {
+                                WebpDrawable webpDrawable = (WebpDrawable) resource;
+                                webpDrawable.setLoopCount(1);
+                                webpDrawable.stop();
+                            }
+                        }
+                    });
         }
     }
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -10,6 +10,9 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.NativeViewHierarchyManager;
+import com.facebook.react.uimanager.UIBlock;
+import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.views.imagehelper.ImageSource;
 
 class FastImageViewModule extends ReactContextBaseJavaModule {
@@ -23,6 +26,19 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
     @Override
     public String getName() {
         return REACT_CLASS;
+    }
+
+    @ReactMethod
+    public void playAnimation(final int reactTag) {
+        final ReactApplicationContext context = getReactApplicationContext();
+        UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+        uiManager.addUIBlock(nvhm -> {
+            FastImageViewWithUrl view = (FastImageViewWithUrl) nvhm.resolveView(reactTag);
+            if (view == null) {
+                return;
+            }
+            view.playAnimation();
+        });
     }
 
     @ReactMethod

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -3,17 +3,13 @@ package com.dylanvann.fastimage;
 import android.app.Activity;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.model.GlideUrl;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.uimanager.NativeViewHierarchyManager;
-import com.facebook.react.uimanager.UIBlock;
 import com.facebook.react.uimanager.UIManagerModule;
-import com.facebook.react.views.imagehelper.ImageSource;
 
 class FastImageViewModule extends ReactContextBaseJavaModule {
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -13,6 +13,7 @@ class FastImageViewWithUrl extends AppCompatImageView {
         if (this.getDrawable() instanceof WebpDrawable) {
             WebpDrawable drawable = (WebpDrawable) this.getDrawable();
             if (!drawable.isRunning()) {
+                drawable.stop();
                 drawable.startFromFirstFrame();
             }
         }

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -1,14 +1,10 @@
 package com.dylanvann.fastimage;
 
 import android.content.Context;
-import android.graphics.drawable.Drawable;
-
 import androidx.appcompat.widget.AppCompatImageView;
 
 import com.bumptech.glide.integration.webp.decoder.WebpDrawable;
 import com.bumptech.glide.load.model.GlideUrl;
-
-import javax.annotation.Nullable;
 
 class FastImageViewWithUrl extends AppCompatImageView {
     public GlideUrl glideUrl;
@@ -19,17 +15,6 @@ class FastImageViewWithUrl extends AppCompatImageView {
             if (!drawable.isRunning()) {
                 drawable.startFromFirstFrame();
             }
-        }
-    }
-
-    @Override
-    public void setImageDrawable(@Nullable Drawable drawable)
-    {
-        super.setImageDrawable(drawable);
-        if (drawable instanceof WebpDrawable) {
-            WebpDrawable webpDrawable = (WebpDrawable) drawable;
-            webpDrawable.setLoopCount(1);
-            webpDrawable.stop();
         }
     }
 

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -1,13 +1,37 @@
 package com.dylanvann.fastimage;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 
 import androidx.appcompat.widget.AppCompatImageView;
 
+import com.bumptech.glide.integration.webp.decoder.WebpDrawable;
 import com.bumptech.glide.load.model.GlideUrl;
+
+import javax.annotation.Nullable;
 
 class FastImageViewWithUrl extends AppCompatImageView {
     public GlideUrl glideUrl;
+
+    public void playAnimation() {
+        if (this.getDrawable() instanceof WebpDrawable) {
+            WebpDrawable drawable = (WebpDrawable) this.getDrawable();
+            if (!drawable.isRunning()) {
+                drawable.startFromFirstFrame();
+            }
+        }
+    }
+
+    @Override
+    public void setImageDrawable(@Nullable Drawable drawable)
+    {
+        super.setImageDrawable(drawable);
+        if (drawable instanceof WebpDrawable) {
+            WebpDrawable webpDrawable = (WebpDrawable) drawable;
+            webpDrawable.setLoopCount(1);
+            webpDrawable.stop();
+        }
+    }
 
     public FastImageViewWithUrl(Context context) {
         super(context);

--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -19,5 +19,7 @@
 @property (nonatomic, strong) FFFastImageSource *source;
 @property (nonatomic, strong) UIColor *imageColor;
 
+- (void)playAnimation;
+
 @end
 

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -1,6 +1,7 @@
 #import "FFFastImageView.h"
 #import <SDWebImage/UIImage+MultiFormat.h>
 #import <SDWebImage/UIView+WebCache.h>
+#import <SDWebImageWebPCoder/SDWebImageWebPCoder.h>
 
 @interface FFFastImageView()
 
@@ -20,7 +21,14 @@
     self = [super init];
     self.resizeMode = RCTResizeModeCover;
     self.clipsToBounds = YES;
+    self.autoPlayAnimatedImage = NO;
+    self.shouldCustomLoopCount = YES;
+    self.animationRepeatCount = 1;
     return self;
+}
+
+- (void)playAnimation {
+    [self.player startPlaying];
 }
 
 - (void)setResizeMode:(RCTResizeMode)resizeMode {
@@ -88,9 +96,14 @@
 }
 
 - (void)sendOnLoad:(UIImage *)image {
+    bool isAnimated = [image.class conformsToProtocol:@protocol(SDAnimatedImage)]
+        ? [(SDAnimatedImage *)image animatedImageFrameCount] > 1
+        : NO;
+    
     self.onLoadEvent = @{
                          @"width":[NSNumber numberWithDouble:image.size.width],
-                         @"height":[NSNumber numberWithDouble:image.size.height]
+                         @"height":[NSNumber numberWithDouble:image.size.height],
+                         @"isAnimated": [NSNumber numberWithBool: isAnimated]
                          };
     if (self.onFastImageLoad) {
         self.onFastImageLoad(self.onLoadEvent);
@@ -196,6 +209,9 @@
 
 - (void)downloadImage:(FFFastImageSource *) source options:(SDWebImageOptions) options context:(SDWebImageContext *)context {
     __weak typeof(self) weakSelf = self; // Always use a weak reference to self in blocks
+    
+    [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]];
+    
     [self sd_setImageWithURL:_source.url
             placeholderImage:nil
                      options:options

--- a/ios/FastImage/FFFastImageView.m
+++ b/ios/FastImage/FFFastImageView.m
@@ -210,8 +210,6 @@
 - (void)downloadImage:(FFFastImageSource *) source options:(SDWebImageOptions) options context:(SDWebImageContext *)context {
     __weak typeof(self) weakSelf = self; // Always use a weak reference to self in blocks
     
-    [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]];
-    
     [self sd_setImageWithURL:_source.url
             placeholderImage:nil
                      options:options

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -1,6 +1,9 @@
 #import "FFFastImageViewManager.h"
 #import "FFFastImageView.h"
 
+#import <React/RCTUIManager.h>
+#import <React/RCTViewManager.h>
+
 #import <SDWebImage/SDImageCache.h>
 #import <SDWebImage/SDWebImagePrefetcher.h>
 
@@ -20,6 +23,18 @@ RCT_EXPORT_VIEW_PROPERTY(onFastImageError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoad, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoadEnd, RCTDirectEventBlock)
 RCT_REMAP_VIEW_PROPERTY(tintColor, imageColor, UIColor)
+
+RCT_EXPORT_METHOD(playAnimation : (nonnull NSNumber *)reactTag)
+{
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+        UIView *view = viewRegistry[reactTag];
+        if (!view || ![view isKindOfClass:[FFFastImageView class]]) {
+          RCTLogError(@"Cannot find NativeView with tag #%@", reactTag);
+          return;
+        }
+        [(FFFastImageView *)view playAnimation];
+    }];
+}
 
 RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)
 {


### PR DESCRIPTION
### Changes:
- Expose the `isAnimated` property in the `onLoad` callback, to let the JS side know if the image is an animated WebP.
- Add the `playAnimation` method that can be called on the `FastImageView` ref to start the animation.